### PR TITLE
Table attributes compatible with Craft 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ The plugin's folder should be named "translate"
 
 Changelog
 =================
+###0.3.5###
+- Added the feature to sort the translations by the original or translated message
+- Adjusted for Craft 2.5
+
+Warning! This version is updated for Craft 2.5 and does NOT work correctly on Craft 2.4
+
 ###0.3.4###
 - Added support for finding translatable strings in object notation
 - Added a MIT license

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -67,12 +67,36 @@ class TranslateElementType extends BaseElementType
     {
         return array(
             array(
-                'original', array('label' => Craft::t('Original')),
+                'original',
+                array(
+                    'label' => Craft::t('Original')
+                ),
             ),
             array(
-                'field', array('label' => Craft::t('Translation')),
+                'field',
+                array(
+                    'label' => Craft::t('Translation')
+                ),
             ),
         );
+    }
+
+    /**
+     * @inheritDoc IElementType::defineSortableAttributes()
+     *
+     * @retrun array
+     */
+    public function defineSortableAttributes()
+    {
+        $sortableAttributes = array();
+
+        foreach ($this->defineTableAttributes() as $index => $attributeDefinition) {
+            foreach($attributeDefinition as $name => $values) {
+                $sortableAttributes[$attributeDefinition[0]] = $attributeDefinition[1]['label'];
+            }
+        }
+
+        return $sortableAttributes;
     }
 
     /**
@@ -241,7 +265,7 @@ class TranslateElementType extends BaseElementType
             'elementType'         => new ElementTypeVariable($this),
             'disabledElementIds'  => $disabledElementIds,
             'attributes'          => $this->defineTableAttributes($sourceKey),
-            'elements'            => craft()->translate->get($criteria),
+            'elements'            => craft()->translate->get($criteria, $viewState),
             'showCheckboxes'      => $showCheckboxes,
         );
 

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -66,8 +66,12 @@ class TranslateElementType extends BaseElementType
     public function defineTableAttributes($source = null)
     {
         return array(
-            'original' => Craft::t('Original'),
-            'field'    => Craft::t('Translation'),
+            array(
+                'original', array('label' => Craft::t('Original')),
+            ),
+            array(
+                'field', array('label' => Craft::t('Translation')),
+            ),
         );
     }
 

--- a/services/TranslateService.php
+++ b/services/TranslateService.php
@@ -104,10 +104,11 @@ class TranslateService extends BaseApplicationComponent
      * Get translations by criteria.
      *
      * @param ElementCriteriaModel $criteria
+     * @param array                $viewState
      *
      * @return array
      */
-    public function get(ElementCriteriaModel $criteria)
+    public function get(ElementCriteriaModel $criteria, $viewState)
     {
         // Ensure source is an array
         if (!is_array($criteria->source)) {
@@ -136,7 +137,7 @@ class TranslateService extends BaseApplicationComponent
                 foreach ($files as $file) {
 
                     // Parse file
-                    $elements = $this->_parseFile($path, $file, $criteria);
+                    $elements = $this->_parseFile($path, $file, $criteria, $viewState);
 
                     // Collect in array
                     $occurences = array_merge($occurences, $elements);
@@ -144,12 +145,21 @@ class TranslateService extends BaseApplicationComponent
             } else {
 
                 // Parse file
-                $elements = $this->_parseFile($path, $path, $criteria);
+                $elements = $this->_parseFile($path, $path, $criteria, $viewState);
 
                 // Collect in array
                 $occurences = array_merge($occurences, $elements);
             }
         }
+
+	    if($viewState['mode'] === 'table') {
+		    if($viewState['sort'] === 'asc') {
+			    ksort($occurences, SORT_NATURAL | SORT_FLAG_CASE);
+		    } else {
+			    krsort($occurences, SORT_NATURAL | SORT_FLAG_CASE);
+		    }
+	    }
+
 
         return $occurences;
     }
@@ -160,10 +170,11 @@ class TranslateService extends BaseApplicationComponent
      * @param string               $path
      * @param string               $file
      * @param ElementCriteriaModel $criteria
+     * @param array                $viewState
      *
      * @return array
      */
-    protected function _parseFile($path, $file, ElementCriteriaModel $criteria)
+    protected function _parseFile($path, $file, ElementCriteriaModel $criteria, $viewState)
     {
         // Collect matches in file
         $occurences = array();
@@ -216,7 +227,11 @@ class TranslateService extends BaseApplicationComponent
                     }
 
                     // Collect in array
-                    $occurences[$original] = $element;
+	                if($viewState['order'] === 'field') {
+		                $occurences[$translation] = $element;
+	                } else {
+		                $occurences[$original] = $element;
+	                }
                 }
             }
         }


### PR DESCRIPTION
Fixes the "An unknown error occurred" message in the Translate tab as described in issue #16 