### PR TITLE
Added node_modules to excluded folders

### DIFF
--- a/services/TranslateService.php
+++ b/services/TranslateService.php
@@ -129,7 +129,7 @@ class TranslateService extends BaseApplicationComponent
             if (!$isFile) {
 
                 // Set filter - no vendor folders, only template files
-                $filter = '^((?!vendor).)*(\.(php|html|twig|js|json|atom|rss)?)$';
+                $filter = '^((?!vendor|node_modules).)*(\.(php|html|twig|js|json|atom|rss)?)$';
 
                 // Get files
                 $files = IOHelper::getFolderContents($path, true, $filter);


### PR DESCRIPTION
I'm developing a plugin that has some heavy javascript usage and use NPM to manage the dependencies. This patch makes the translate plugin ignore any node_modules folders.