### PR TITLE
Added support for sites with a single locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ phpunit --bootstrap craft/app/tests/bootstrap.php --configuration craft/plugins/
 
 Changelog
 =================
+###0.4.3###
+- Fixed a bug where translations wouldn't be shown on sites with only 1 locale defined
+
 ###0.4.2###
 - Add node_modules to excluded vendor folders (thanks to @tcsehv)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ phpunit --bootstrap craft/app/tests/bootstrap.php --configuration craft/plugins/
 Changelog
 =================
 ###0.4.3###
-- Fixed a bug where translations wouldn't be shown on sites with only 1 locale defined
+- Fixed a bug where translations wouldn't be shown on sites with only 1 locale defined (thanks to @janhenckens)
 
 ###0.4.2###
 - Add node_modules to excluded vendor folders (thanks to @tcsehv)

--- a/TranslatePlugin.php
+++ b/TranslatePlugin.php
@@ -30,7 +30,7 @@ class TranslatePlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '0.4.2';
+        return '0.4.3';
     }
 
     /**

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -243,8 +243,7 @@ class TranslateElementType extends BaseElementType
     {
         // If the site only has 1 locale enabled, set the translated locale to the primary (and only) locale
         if(empty($criteria['locale'])) {
-            $localization = new LocalizationService();
-            $criteria['locale'] = $localization->getPrimarySiteLocale();
+            $criteria['locale'] = craft()->i18n->getPrimarySiteLocale()
         }
 
         $variables = array(

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -243,7 +243,7 @@ class TranslateElementType extends BaseElementType
     {
         // If the site only has 1 locale enabled, set the translated locale to the primary (and only) locale
         if(empty($criteria['locale'])) {
-            $criteria['locale'] = craft()->i18n->getPrimarySiteLocale()
+            $criteria['locale'] = craft()->i18n->getPrimarySiteLocale();
         }
 
         $variables = array(

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -242,7 +242,7 @@ class TranslateElementType extends BaseElementType
     public function getIndexHtml($criteria, $disabledElementIds, $viewState, $sourceKey, $context, $includeContainer, $showCheckboxes)
     {
         // If the site only has 1 locale enabled, set the translated locale to the primary (and only) locale
-        if(empty($criteria['locale'])) {
+        if (empty($criteria['locale'])) {
             $criteria['locale'] = craft()->i18n->getPrimarySiteLocale();
         }
 

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -241,6 +241,12 @@ class TranslateElementType extends BaseElementType
      */
     public function getIndexHtml($criteria, $disabledElementIds, $viewState, $sourceKey, $context, $includeContainer, $showCheckboxes)
     {
+        // If the site only has 1 locale enabled, set the translated locale to the primary (and only) locale
+        if(empty($criteria['locale'])) {
+            $localization = new LocalizationService();
+            $criteria['locale'] = $localization->getPrimarySiteLocale();
+        }
+
         $variables = array(
             'viewMode' => $viewState['mode'],
             'context' => $context,


### PR DESCRIPTION
On sites that only have a single locale enabled, the plugin would not show translated strings in the translation overview. 

Strings will show up translated where they're used in templates so that works, just not in the plugin where you do the translating itself and that can be a bit confusing.

The PR checks if we have a locale and if we don't, it sets it locale to the primary (and only) locale defined on the site.