### PR TITLE
Escaping Issue when cell has a /

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ phpunit --bootstrap craft/app/tests/bootstrap.php --configuration craft/plugins/
 
 Changelog
 =================
+###0.4.3###
+- Fixed a bug where translations wouldn't be shown on sites with only 1 locale defined (thanks to @janhenckens)
+
 ###0.4.2###
 - Add node_modules to excluded vendor folders (thanks to @tcsehv)
 

--- a/TranslatePlugin.php
+++ b/TranslatePlugin.php
@@ -30,7 +30,7 @@ class TranslatePlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '0.4.2';
+        return '0.4.3';
     }
 
     /**

--- a/elementtypes/TranslateElementType.php
+++ b/elementtypes/TranslateElementType.php
@@ -241,6 +241,11 @@ class TranslateElementType extends BaseElementType
      */
     public function getIndexHtml($criteria, $disabledElementIds, $viewState, $sourceKey, $context, $includeContainer, $showCheckboxes)
     {
+        // If the site only has 1 locale enabled, set the translated locale to the primary (and only) locale
+        if (empty($criteria['locale'])) {
+            $criteria['locale'] = craft()->i18n->getPrimarySiteLocale();
+        }
+
         $variables = array(
             'viewMode' => $viewState['mode'],
             'context' => $context,


### PR DESCRIPTION
Undefined index error in upload where a translatable field has a `\`. fgetcsv is parsing it as one cell. 

Example: 
`"Choose what type of feed you\","Choose what type of feed you\"`

Fix:

`    public function actionUpload()
    {
        // Get params
        $locale = craft()->request->getRequiredPost('locale');

        // Get file
        $file = \CUploadedFile::getInstanceByName('translations-upload');

        // Get filepath
        $path = craft()->path->getTempUploadsPath().$file->getName();

        // Save file to Craft's temp folder
        $file->saveAs($path);

        // Open file and parse csv rows
        $translations = array();
        $handle = fopen($path, 'r');
        while (($row = fgetcsv($handle, 0, ',', '"', '"')) !== false) {
            $translations[$row[0]] = $row[1];
        }
        fclose($handle);

        // Save
        craft()->translate->set($locale, $translations);

        // Set a flash message
        craft()->userSession->setNotice(Craft::t('The translations have been updated.'));

        // Redirect back to page
        $this->redirectToPostedUrl();
    }`
